### PR TITLE
Fix raw_values mutation that broke repeated raw= searches

### DIFF
--- a/psycodict/searchtable.py
+++ b/psycodict/searchtable.py
@@ -489,13 +489,26 @@ class PostgresSearchTable(PostgresTable):
             sage: statement, vals = db.nf_fields._build_query({"class_number":1}, 20)
             sage: statement.as_string(db.conn), vals
             (' WHERE "class_number" = %s ORDER BY "id" LIMIT %s', [1, 20])
+
+        A ``raw_values`` list passed in by the caller is not mutated, even
+        though the limit and offset are appended to the returned values::
+
+            sage: raw_values = []
+            sage: statement, vals = db.nf_fields._build_query({}, 20, raw="degree = 2", raw_values=raw_values)
+            sage: statement.as_string(db.conn), vals
+            (' WHERE degree = 2 ORDER BY "degree", "disc_abs", "disc_sign", "iso_number" LIMIT %s', [20])
+            sage: raw_values
+            []
         """
         if raw_values is None:
             raw_values = []
         if raw is None:
             qstr, values = self._parse_dict(query)
         else:
-            qstr, values = SQL(raw), raw_values
+            # Copy raw_values: we append limit/offset to ``values`` below, and
+            # must not mutate the list passed in by the caller (in particular
+            # the shared default of search()/lucky()).
+            qstr, values = SQL(raw), list(raw_values)
         if qstr is None:
             where = SQL("")
             values = []
@@ -630,7 +643,7 @@ class PostgresSearchTable(PostgresTable):
         else:
             return Identifier(self.search_table)
 
-    def lucky(self, query={}, projection=2, offset=0, sort=[], raw=None, raw_values=[]):
+    def lucky(self, query={}, projection=2, offset=0, sort=[], raw=None, raw_values=None):
         # FIXME Nulls aka Nones are being erased, we should perhaps just leave them there
         """
         One of the two main public interfaces for performing SELECT queries,
@@ -721,7 +734,7 @@ class PostgresSearchTable(PostgresTable):
         one_per=None,
         silent=False,
         raw=None,
-        raw_values=[],
+        raw_values=None,
     ):
         """
         One of the two main public interfaces for performing SELECT queries,


### PR DESCRIPTION
## The bug

`search()` and `lucky()` declare a mutable default `raw_values=[]`, and `_build_query` aliases that list before appending the limit/offset:

```python
qstr, values = SQL(raw), raw_values   # values IS the caller's (default) list
...
if limit is not None:
    values.append(limit)              # mutates it
    if offset != 0:
        values.append(offset)
```

So the **first** `raw=` search in a process works, but every subsequent one inherits the accumulated `limit`/`offset` from the shared default list. The generated SQL then has fewer `%s` placeholders than values, and the query dies with:

```
TypeError: not all arguments converted during string formatting
```

A caller that passes its own `raw_values` list is also affected — the list is mutated as a side effect of the search.

### Reproduce

```python
from lmfdb import db
nf = db.nf_fields
list(nf.search({}, projection=["label"], limit=3, raw="degree = 2"))  # ok
list(nf.search({}, projection=["label"], limit=3, raw="degree = 2"))  # TypeError
```

## The fix

- Copy `raw_values` in `_build_query` (`values = list(raw_values)`) so the caller's list is never mutated.
- Change the mutable defaults in `search()` and `lucky()` from `[]` to `None` (`_build_query` already coalesces `None` to `[]`).

After the fix, repeated `raw=` searches succeed and a caller-supplied `raw_values` list is left untouched. Added a doctest in `_build_query` demonstrating both.

(Found while adding a command-line raw-SQL search to the LMFDB.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)